### PR TITLE
Properly fill in the error message fields in the message

### DIFF
--- a/src/cose.test.ts
+++ b/src/cose.test.ts
@@ -3,3 +3,35 @@ import * as cose from "./cose";
 describe("cose", () => {
   test.skip("encodeCoseKey", () => {});
 });
+
+describe("OmniError", function () {
+  it('replaces fields', () => {
+    const error = {
+      [0]: 123,
+      [1]: "Hello {0} and {2}.",
+      [2]: {
+        "0": "ZERO",
+        "1": "ONE",
+        "2": "TWO",
+      }
+    };
+    const err = new cose.OmniError(error);
+
+    expect(err.toString()).toBe("Error: Hello ZERO and TWO.");
+  });
+
+  it('works with double brackets', () => {
+    const error = {
+      [0]: 123,
+      [1]: "/{{}}{{{0}}}{{{a}}}{b}}}{{{2}.",
+      [2]: {
+        "0": "ZERO",
+        "1": "ONE",
+        "2": "TWO",
+      }
+    };
+    const err = new cose.OmniError(error);
+
+    expect(err.toString()).toBe("Error: /{}{ZERO}{}}{TWO.");
+  });
+});


### PR DESCRIPTION
In case the message does not exist returns a generic message with all
the fields.

Fixes #2. We do not want to subclass the Error type further to avoid a
lot of bloat in the JS files. Just having the fields should be enough.