### PR TITLE
fixes failing test in Message

### DIFF
--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -61,7 +61,6 @@ export class Message {
         Object.fromEntries(data.entries()) as SerializedManyError
       );
     }
-    content.set(4, cbor.decodeFirstSync(data));
     return new Message(content);
   }
 

--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -18,6 +18,8 @@ interface MessageContent {
   attrs?: string[];
 }
 
+export const DEFAULT_MESSAGE_DATA = cbor.encode(new ArrayBuffer(0));
+
 export class Message {
   constructor(public content: CborMap) {}
 
@@ -34,7 +36,7 @@ export class Message {
       content.set(2, obj.to.toString());
     }
     content.set(3, obj.method);
-    content.set(4, cbor.encode(obj.data ? obj.data : new ArrayBuffer(0)));
+    content.set(4, obj.data ? cbor.encode(obj.data) : DEFAULT_MESSAGE_DATA);
     content.set(
       5,
       tag(1, obj.timestamp ? obj.timestamp : Math.floor(Date.now() / 1000))

--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -18,8 +18,6 @@ interface MessageContent {
   attrs?: string[];
 }
 
-export const DEFAULT_MESSAGE_DATA = cbor.encode(new ArrayBuffer(0));
-
 export class Message {
   constructor(public content: CborMap) {}
 
@@ -36,7 +34,9 @@ export class Message {
       content.set(2, obj.to.toString());
     }
     content.set(3, obj.method);
-    content.set(4, obj.data ? cbor.encode(obj.data) : DEFAULT_MESSAGE_DATA);
+    if (obj.data) {
+      content.set(4, cbor.encode(obj.data));
+    }
     content.set(
       5,
       tag(1, obj.timestamp ? obj.timestamp : Math.floor(Date.now() / 1000))

--- a/src/message/message.test.ts
+++ b/src/message/message.test.ts
@@ -13,12 +13,6 @@ describe("Message", () => {
     const req = Message.fromObject(msg);
     const cborData = req.toCborData();
     const fromCborMessage = Message.fromCborData(cborData);
-    /*
-      need to set message.content[4] to the default data because
-      Message.fromObject sets it to that if data doesn't exist
-    */
-    fromCborMessage.content.set(4, DEFAULT_MESSAGE_DATA);
-
     expect(fromCborMessage).toStrictEqual(req);
   });
 });

--- a/src/message/message.test.ts
+++ b/src/message/message.test.ts
@@ -1,4 +1,4 @@
-import { Message, DEFAULT_MESSAGE_DATA } from "../message";
+import { Message } from "../message";
 import cbor from "cbor";
 
 describe("Message", () => {

--- a/src/message/message.test.ts
+++ b/src/message/message.test.ts
@@ -1,5 +1,4 @@
 import { Message } from "../message";
-import cbor from "cbor";
 
 describe("Message", () => {
   test("can be constructed from an object", () => {

--- a/src/message/message.test.ts
+++ b/src/message/message.test.ts
@@ -11,8 +11,8 @@ describe("Message", () => {
   test("can be serialized/deserialized", () => {
     const msg = { method: "info" };
     const req = Message.fromObject(msg);
-    const cborData = req.toCborData();
-    const fromCborMessage = Message.fromCborData(cborData);
-    expect(fromCborMessage).toStrictEqual(req);
+    const cbor = req.toCborData();
+
+    expect(Message.fromCborData(cbor)).toStrictEqual(req);
   });
 });

--- a/src/message/message.test.ts
+++ b/src/message/message.test.ts
@@ -1,4 +1,5 @@
-import { Message } from "../message";
+import { Message, DEFAULT_MESSAGE_DATA } from "../message";
+import cbor from "cbor";
 
 describe("Message", () => {
   test("can be constructed from an object", () => {
@@ -10,8 +11,14 @@ describe("Message", () => {
   test("can be serialized/deserialized", () => {
     const msg = { method: "info" };
     const req = Message.fromObject(msg);
-    const cbor = req.toCborData();
+    const cborData = req.toCborData();
+    const fromCborMessage = Message.fromCborData(cborData);
+    /*
+      need to set message.content[4] to the default data because
+      Message.fromObject sets it to that if data doesn't exist
+    */
+    fromCborMessage.content.set(4, DEFAULT_MESSAGE_DATA);
 
-    expect(Message.fromCborData(cbor)).toStrictEqual(req);
+    expect(fromCborMessage).toStrictEqual(req);
   });
 });


### PR DESCRIPTION
in `Message.fromCoseMessage`, `data` is set to the decoded cbor data per `content.set(4, cbor.decodeFirstSync(data));`
in `Message.fromObject`, `data` is cbor encoded per `content.set(4, cbor.encode(obj.data ? obj.data : new ArrayBuffer(0)));`

in the test we have:
```javascript
    const req = Message.fromObject(msg);
    const cbor = req.toCborData();
    expect(Message.fromCborData(cbor)).toStrictEqual(req);
```
the test is failing because the comparison between the `data` from `Message.fromCborData(cbor)` (calls `Message.fromCoseMessage`) and `Message.fromObject` is not the same because we are comparing the cbor encoded data in `req` to the cbor decoded data in `Message.fromCborData(cbor)`

