### PR TITLE
change base32encode dep version 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/uuid": "^8.3.3",
         "@typescript-eslint/parser": "^5.7.0",
         "base32-decode": "^1.0.0",
-        "base32-encode": "^2.0.0",
+        "base32-encode": "^1.2.0",
         "bip39": "^3.0.4",
         "cbor": "^8.1.0",
         "crc": "^3.8.0",
@@ -1453,14 +1453,11 @@
       "integrity": "sha512-KNWUX/R7wKenwE/G/qFMzGScOgVntOmbE27vvc6GrniDGYb6a5+qWcuoXl8WIOQL7q0TpK7nZDm1Y04Yi3Yn5g=="
     },
     "node_modules/base32-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-2.0.0.tgz",
-      "integrity": "sha512-mlmkfc2WqdDtMl/id4qm3A7RjW6jxcbAoMjdRmsPiwQP0ufD4oXItYMnPgVHe80lnAIy+1xwzhHE1s4FoIceSw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
+      "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
       "dependencies": {
-        "to-data-view": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "to-data-view": "^1.1.0"
       }
     },
     "node_modules/base64-js": {
@@ -4491,12 +4488,9 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
     "node_modules/to-data-view": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-2.0.0.tgz",
-      "integrity": "sha512-RGEM5KqlPHr+WVTPmGNAXNeFEmsBnlkxXaIfEpUYV0AST2Z5W1EGq9L/MENFrMMmL2WQr1wjkmZy/M92eKhjYA==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
+      "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -5984,11 +5978,11 @@
       "integrity": "sha512-KNWUX/R7wKenwE/G/qFMzGScOgVntOmbE27vvc6GrniDGYb6a5+qWcuoXl8WIOQL7q0TpK7nZDm1Y04Yi3Yn5g=="
     },
     "base32-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-2.0.0.tgz",
-      "integrity": "sha512-mlmkfc2WqdDtMl/id4qm3A7RjW6jxcbAoMjdRmsPiwQP0ufD4oXItYMnPgVHe80lnAIy+1xwzhHE1s4FoIceSw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
+      "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
       "requires": {
-        "to-data-view": "^2.0.0"
+        "to-data-view": "^1.1.0"
       }
     },
     "base64-js": {
@@ -8221,9 +8215,9 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
     "to-data-view": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-2.0.0.tgz",
-      "integrity": "sha512-RGEM5KqlPHr+WVTPmGNAXNeFEmsBnlkxXaIfEpUYV0AST2Z5W1EGq9L/MENFrMMmL2WQr1wjkmZy/M92eKhjYA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
+      "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/uuid": "^8.3.3",
     "@typescript-eslint/parser": "^5.7.0",
     "base32-decode": "^1.0.0",
-    "base32-encode": "^2.0.0",
+    "base32-encode": "^1.2.0",
     "bip39": "^3.0.4",
     "cbor": "^8.1.0",
     "crc": "^3.8.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "lib": ["dom", "esnext"],
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "outDir": "dist",


### PR DESCRIPTION
changes `base32-encode` version so jest from create react app will get along.
Existing tests are still passing.